### PR TITLE
Ugly hack to make HTTPS work from Docker

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -194,10 +194,11 @@ import com.typesafe.sbt.packager.docker.{Cmd, ExecCmd}
 import com.typesafe.sbt.packager.docker.DockerChmodType
 
 Universal / mappings += file("docker/start.sh") -> "bin/start"
+Universal / mappings += file("docker/target/dev-mode/") -> "target/dev-mode/"
 
 dockerUpdateLatest := true
 dockerBaseImage := "adoptopenjdk/openjdk8:alpine-slim"
-dockerChmodType := DockerChmodType.Custom("u=rwX,g=rX,o-rwx")
+dockerChmodType := DockerChmodType.UserGroupWriteExecute
 dockerExposedPorts ++= Seq(8080, 8443)
 dockerEntrypoint := Seq("/opt/docker/bin/start")
 


### PR DESCRIPTION
This is an ugly hack but it works. With the previous value for `dockerChmodType`, the working directory was [not writeable by the daemon user](https://www.scala-sbt.org/sbt-native-packager/formats/docker.html#file-permission). However, that in itself is not enough, because the working directory itself does not actually have its permissions altered by `COPY --chown`. I couldn't find a nicer way to create the directory afterwards / change the permissions of the working directory itself. This fixes it by making sure the directory already exists in the image.