### PR TITLE
Add docker build script that includes building ID7

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ ITS web applications (e.g. [Tabula](https://github.com/UniversityofWarwick/tabul
 This application ships with Docker support. To build, tag and run a local container image, perform the following steps:
 
 ```
- $ ./sbt docker:stage
- $ ./sbt docker:publishLocal
+ $ ./buildDocker.sh
  $ docker run -p 127.0.0.1:8090:8080 sso-stub
 ```
 

--- a/buildDocker.sh
+++ b/buildDocker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+ls -lha target/assets/style.css 2>/dev/null 1>/dev/null || (npm ci && npm run build)
+./sbt docker:stage
+./sbt docker:publishLocal


### PR DESCRIPTION
This PR adds a new script, `buildDocker.sh`, which builds the docker image, including the same check to ensure ID7 is built that `run.sh` has (the main reason for this PR is the instructions for docker didn't mention ID7, so building the docker image without ever running locally led to there being no styling).