### PR TITLE
Handle NPM in SBT.

### DIFF
--- a/buildDocker.sh
+++ b/buildDocker.sh
@@ -1,4 +1,2 @@
 #!/bin/bash
-ls -lha target/assets/style.css 2>/dev/null 1>/dev/null || (npm ci && npm run build)
-./sbt docker:stage
-./sbt docker:publishLocal
+./sbt "; docker:stage; docker:publishLocal"


### PR DESCRIPTION
Bit of an evolution over Oscar's PR and Adam's subsequent SBT twerks

Uses the Changed helper so it only runs 'npm ci' if package.json does (maybe package-lock.json is the better option though).

build script is modified to not run npm itself, and also puts the two SBT tasks into one call to SBT, to make it faster.