### PR TITLE
Remove allowed hosts list for docker

### DIFF
--- a/conf/local-dev.conf
+++ b/conf/local-dev.conf
@@ -1,4 +1,5 @@
 play.http.secret.key="changeme"
 
 app.webgroup.prefix="in-"${app.name.id}"-local-dev-"
-play.filters.disabled+=play.filters.hosts.AllowedHostsFilter
+
+play.filters.disabled += play.filters.hosts.AllowedHostsFilter

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -8,7 +8,7 @@ play.http.secret.key="$key"
 
 app.webgroup.prefix="in-"\${app.name.id}"-local-dev-"
 
-play.filters.disabled+=play.filters.hosts.AllowedHostsFilter
+play.filters.disabled += play.filters.hosts.AllowedHostsFilter
 EOF
 
 export PLAY_HTTPS_PORT=8443

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -7,9 +7,8 @@ cat <<EOF > /opt/docker/conf/local-dev.conf
 play.http.secret.key="$key"
 
 app.webgroup.prefix="in-"\${app.name.id}"-local-dev-"
-play.filters.hosts {
-  allowed = ["localhost:8090", "localhost:8443"]
-}
+
+play.filters.disabled+=play.filters.hosts.AllowedHostsFilter
 EOF
 
 export PLAY_HTTPS_PORT=8443


### PR DESCRIPTION
This PR removes the allowed hosts list for the docker config, like https://github.com/UniversityofWarwick/sso-stub/commit/bca03d6634b975e05cb3c715fab9318e2555150b did for the normal config